### PR TITLE
Strip s3 key path with os.path.sep

### DIFF
--- a/s3peat/__init__.py
+++ b/s3peat/__init__.py
@@ -179,8 +179,8 @@ class S3Queue(Thread):
         if self.strip_path and filename.startswith(self.strip_path):
             filename = filename[len(self.strip_path):]
 
-        # Strip the filename of leading slashies
-        filename = filename.lstrip('/')
+        # Strip the filename of leading path separators
+        filename = filename.lstrip(os.path.sep)
         # Join it to the prefix and go!
         return '/'.join((self.prefix, filename))
 


### PR DESCRIPTION
Fixes issue on Windows where files would be uploaded with s3 keys
beginning with "\".
