### PR TITLE
Add Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ develop-eggs
 lib
 lib64
 __pycache__
+*.bak
 
 # Installer logs
 pip-log.txt

--- a/s3peat/__init__.py
+++ b/s3peat/__init__.py
@@ -23,6 +23,9 @@ s3peat - Fast uploading directories to S3
 
 """
 from __future__ import print_function
+from builtins import str
+from builtins import range
+from builtins import object
 import os
 import posixpath
 import sys
@@ -330,8 +333,8 @@ class S3Uploader(object):
                 self.total += 1
 
         if split:
-            groups = [list() for i in xrange(self.concurrency)]
-            for i in xrange(len(filenames)):
+            groups = [list() for i in range(self.concurrency)]
+            for i in range(len(filenames)):
                 groups[i % self.concurrency].append(filenames[i])
             filenames = groups
 

--- a/s3peat/__init__.py
+++ b/s3peat/__init__.py
@@ -22,6 +22,7 @@ s3peat - Fast uploading directories to S3
 
 
 """
+from __future__ import print_function
 import os
 import posixpath
 import sys
@@ -68,8 +69,8 @@ class S3Bucket(object):
         try:
             return conn.get_bucket(self.name)
         except NoAuthHandlerFound:
-            print >>sys.stderr, ("AWS credentials not properly configured, "
-                    "please supply --key and --secret arguments.")
+            print(("AWS credentials not properly configured, "
+                    "please supply --key and --secret arguments."), file=sys.stderr)
             sys.exit(1)
 
     def __str__(self):
@@ -283,8 +284,8 @@ class S3Uploader(object):
         which means the current files will finish.
 
         """
-        print >>sys.stderr, "                                                 "
-        print >>sys.stderr, "Stopping...                                      "
+        print("                                                 ", file=sys.stderr)
+        print("Stopping...                                      ", file=sys.stderr)
         for queue in self.queues:
             queue.filenames = []
         sys.exit(1)

--- a/s3peat/scripts.py
+++ b/s3peat/scripts.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import str
 import os
 import re
 import sys

--- a/s3peat/scripts.py
+++ b/s3peat/scripts.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import re
 import sys
@@ -56,7 +57,7 @@ class Main(Command):
         """
         a = self.args  # Shorthand
         if a.concurrency < 1:
-            print >>sys.stderr, "Concurrency must be positive."
+            print("Concurrency must be positive.", file=sys.stderr)
             sys.exit(1)
 
         if a.verbose > 2:
@@ -89,14 +90,14 @@ class Main(Command):
         try:
             # Start the upload
             filenames = uploader.upload()
-        except IOError, exc:
-            print >>sys.stderr, str(exc)
+        except IOError as exc:
+            print(str(exc), file=sys.stderr)
             sys.exit(1)
 
         if filenames:
             # If any files were returned, that means they failed to upload
-            print >>sys.stderr, "Error uploading files:"
-            print >>sys.stderr, "\n".join(filenames)
+            print("Error uploading files:", file=sys.stderr)
+            print("\n".join(filenames), file=sys.stderr)
             sys.exit(1)
 
         # This call isn't really necessary, but whatevs
@@ -113,9 +114,9 @@ class Main(Command):
         """
         a = self.args  # Shorthand
         if a.verbose > 1:
-            print "Finding files in {} ...".format(
-                    os.path.realpath(a.directory))
-            print
+            print("Finding files in {} ...".format(
+                    os.path.realpath(a.directory)))
+            print()
 
         # Use a dummy bucket and uploader to get the file names
         bucket = None
@@ -124,35 +125,35 @@ class Main(Command):
         filenames = uploader.get_filenames()
 
         if a.verbose > 1:
-            print '\n'.join(filenames)
-            print
+            print('\n'.join(filenames))
+            print()
 
         if filenames:
-            print "{} files found.".format(uploader.total)
+            print("{} files found.".format(uploader.total))
         else:
-            print >>sys.stderr, "No files found."
+            print("No files found.", file=sys.stderr)
             sys.exit(1)
 
         if a.verbose > 1:
-            print
+            print()
 
         # Test the connection to S3
         bucket = s3peat.S3Bucket(a.bucket, a.key, a.secret)
         try:
             bucket.get_new()
-        except Exception, exc:
-            print >>sys.stderr, "Error connecting to S3 bucket {!r}.".format(
-                    a.bucket)
+        except Exception as exc:
+            print("Error connecting to S3 bucket {!r}.".format(
+                    a.bucket), file=sys.stderr)
 
             if a.verbose > 1:
-                print >>sys.stderr, '   ', '\n    '.join(repr(exc).split('\n'))
+                print('   ', '\n    '.join(repr(exc).split('\n')), file=sys.stderr)
             elif a.verbose:
-                print >>sys.stderr, '   ', repr(exc).split('\n')[0]
+                print('   ', repr(exc).split('\n')[0], file=sys.stderr)
 
             sys.exit(1)
         else:
             if a.verbose:
-                print "Connected to S3 bucket {!r} OK.".format(a.bucket)
+                print("Connected to S3 bucket {!r} OK.".format(a.bucket))
 
         self.stop()
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readme():
 setup(
         name='s3peat',
         # Make sure to also update the version in s3peat/__init__.py
-        version='0.5.1',
+        version='0.5.2-alpha',
         author="Jacob Alheid",
         author_email="jake@about.me",
         description="Fast uploader to S3",


### PR DESCRIPTION
This PR adds Python 3 improvements to s3peat. It's been tested on Python 3.4+

Python 2.7+ can still use the `0.5.1` release.

I used [2to3](https://docs.python.org/2/library/2to3.html) to update the code. This version is currently tagged as `0.5.2-alpha` but I'm happy to adjust it. Thanks! 